### PR TITLE
feat: Adds warning about readonly arrays.

### DIFF
--- a/configs/tslint.json
+++ b/configs/tslint.json
@@ -7,7 +7,9 @@
     "no-unused": true,
     "early-exit": true,
     "readonly-keyword": true,
-    "readonly-array": false,
+    "readonly-array": {
+      "severity": "warning"
+    },
     "no-let": true,
     "no-this": true,
     "no-class": true,


### PR DESCRIPTION
- [Rule documentation](https://github.com/jonaskello/tslint-immutable#readonly-array)
- [Blog post on mutation alternatives](https://lorenstewart.me/2017/01/22/javascript-array-methods-mutating-vs-non-mutating/)

Right now this gets auto-fixed by VS Code in inappropriate places forcing you to disable the rule in those places. For example, when utilising a library that isn't defining an input as a ReadonlyArray you have to pass through a regular array otherwise `pop` and other functions will be missing.