### PR TITLE
feat: Adds ES Module Interop to allow default imports

### DIFF
--- a/configs/tsconfig.json
+++ b/configs/tsconfig.json
@@ -21,7 +21,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedParameters": true,
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "esModuleInterop": true
   },
   "includes": [
     "src/**/*"


### PR DESCRIPTION
BREAKING CHANGE: `import * as foobar from 'foobar'` must be changed to `import foobar from 'foobar'` for modules using `exports = foobar`.