### PR TITLE
fix(TS Config): Corrects 'includes' typo to 'include'

### DIFF
--- a/configs/tsconfig.json
+++ b/configs/tsconfig.json
@@ -24,7 +24,7 @@
     "noUnusedLocals": false,
     "esModuleInterop": true
   },
-  "includes": [
+  "include": [
     "src/**/*"
   ],
   "exclude": [


### PR DESCRIPTION
First noticed this issue in #11 when running TSC with the showConfig option.

https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#examples